### PR TITLE
Handle tool partial rewards

### DIFF
--- a/docs/sglang_multiturn/sandbox_fusion.rst
+++ b/docs/sglang_multiturn/sandbox_fusion.rst
@@ -184,7 +184,7 @@ Tool Implementation
             else:
                 return "no stdout here"
 
-       async def calc_reward(self, instance_id: str, ...):
+       async def calc_final_reward(self, instance_id: str, ...):
            ...
 
        async def release(self, instance_id: str, ...):

--- a/verl/tools/gsm8k_tool.py
+++ b/verl/tools/gsm8k_tool.py
@@ -33,7 +33,7 @@ class Gsm8kTool(BaseTool):
     - `to_openai_function_tool_schema`: return the tool schema in OpenAI format.
     - `create`: create a tool instance for a trajectory.
     - `execute`: execute the tool.
-    - `calc_reward`: calculate the reward respect to tool state.
+    - `calc_final_reward`: calculate the reward respect to tool state.
     - `release`: release the tool instance.
     """
 
@@ -83,15 +83,22 @@ class Gsm8kTool(BaseTool):
         else:
             self._instance_dict[instance_id]["response"] = "#### " + answer
 
-        reward = await self.calc_reward(instance_id)
+        reward = await self.calc_final_reward(instance_id)
         # penalty for non improved answer submission
         tool_reward = 0.0 if reward > self._instance_dict[instance_id]["reward"] else -0.05
         # update the reward
         self._instance_dict[instance_id]["reward"] = reward
+        response = f"Current parsed {answer=} {reward=}"
+        metrics: dict = {}
+        self.record_step_result(
+            parameters=parameters,
+            response=response,
+            reward=tool_reward,
+            metrics=metrics,
+        )
+        return response, tool_reward, metrics
 
-        return f"Current parsed {answer=} {reward=}", tool_reward, {}
-
-    async def calc_reward(self, instance_id: str, **kwargs) -> float:
+    async def calc_final_reward(self, instance_id: str, **kwargs) -> float:
         return gsm8k.compute_score(
             self._instance_dict[instance_id]["response"],
             self._instance_dict[instance_id]["ground_truth"],

--- a/verl/tools/mcp_base_tool.py
+++ b/verl/tools/mcp_base_tool.py
@@ -87,8 +87,18 @@ class MCPBaseTool(BaseTool):
             # Store results in instance dictionary
             self._instance_dict[instance_id]["reward"].append(result_text.strip())
 
-            # Convert metadata to metrics
-            metrics = {"query_count": metadata.get("query_count", 0), "status": metadata.get("status", "unknown"), "total_results": metadata.get("total_results", 0), "api_request_error": metadata.get("api_request_error")}
+            metrics = {
+                "query_count": metadata.get("query_count", 0),
+                "status": metadata.get("status", "unknown"),
+                "total_results": metadata.get("total_results", 0),
+                "api_request_error": metadata.get("api_request_error"),
+            }
+            self.record_step_result(
+                parameters=parameters,
+                response=result_text,
+                reward=0.0,
+                metrics=metrics,
+            )
 
             return result_text, 0.0, metrics
 
@@ -97,7 +107,7 @@ class MCPBaseTool(BaseTool):
             logger.error(f"[MCPBaseTool] Execution failed: {e}")
             return error_result, 0.0, {"error": str(e)}
 
-    async def calc_reward(self, instance_id: str, **kwargs) -> str:
+    async def calc_final_reward(self, instance_id: str, **kwargs) -> str:
         return self._instance_dict[instance_id]["reward"]
 
     async def release(self, instance_id: str, **kwargs) -> None:

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -77,12 +77,15 @@ class NaiveRewardManager:
             data_source = data_item.non_tensor_batch[self.reward_fn_key]
             extra_info = data_item.non_tensor_batch.get("extra_info", None)
 
-            score = self.compute_score(
-                data_source=data_source,
-                solution_str=response_str,
-                ground_truth=ground_truth,
-                extra_info=extra_info,
-            )
+            if isinstance(extra_info, dict) and "reward" in extra_info:
+                score = extra_info["reward"]
+            else:
+                score = self.compute_score(
+                    data_source=data_source,
+                    solution_str=response_str,
+                    ground_truth=ground_truth,
+                    extra_info=extra_info,
+                )
 
             if isinstance(score, dict):
                 reward = score["score"]


### PR DESCRIPTION
## Summary
- record tool step details in `BaseTool` via `record_step_result`
- capture each tool call step result during execution
- propagate partial rewards in SGLang rollout
- allow reward managers to use provided reward data

## Testing
- `pre-commit run --files verl/tools/base_tool.py verl/tools/geo3k_tool.py verl/tools/gsm8k_tool.py verl/tools/mcp_base_tool.py verl/tools/sandbox_fusion_tools.py verl/tools/search_tool.py` *(fails: command not found)*
- `pytest -k test_base_tool_on_cpu -q` *(fails to collect tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c7586918483209864cde2a9c9fa1e